### PR TITLE
Develop 162 draft wrapper

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -21,9 +21,9 @@ externals = Externals.cfg
 required = True
 
 [cmeps]
-tag = cmeps0.13.70
+branch = develop-add-linked-libs
 protocol = git
-repo_url = https://github.com/ESCOMP/CMEPS.git
+repo_url = https://github.com/mattldawson/CMEPS.git
 local_path = components/cmeps
 required = True
 
@@ -107,20 +107,6 @@ tag = rtm1_0_78
 protocol = git
 repo_url = https://github.com/ESCOMP/RTM
 local_path = components/rtm
-required = True
-
-[tuv-x]
-local_path = libraries/tuv-x
-protocol = git
-repo_url = https://github.com/NCAR/tuv-x.git
-branch = develop-160-cesm-build
-required = True
-
-[json-fortran]
-local_path = libraries/json-fortran
-protocol = git
-repo_url = https://github.com/jacobwilliams/json-fortran.git
-tag = 8.2.1
 required = True
 
 [cam]

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -145,6 +145,8 @@ def _cmake_default_args(caseroot):
 ###############################################################################
 def _build_json_fortran(caseroot, libroot, bldroot):
 ###############################################################################
+# Builds the json-fortran library and updates the case variables used to set
+# the include paths and linked libraries
 
     with Case(caseroot) as case:
         bldpath = os.path.join(bldroot, "json-fortran")
@@ -152,7 +154,7 @@ def _build_json_fortran(caseroot, libroot, bldroot):
             os.makedirs(bldpath)
         srcpath = os.path.abspath(os.path.join(case.get_value("COMP_ROOT_DIR_ATM"), \
                                                "libraries", "json-fortran", ""))
-        logger.info("Building json-fortran {} from source in {}\n".format(bldpath, srcpath))
+        logger.info("Building json-fortran in {} from source in {}\n".format(bldpath, srcpath))
 
         arg_dict = _cmake_default_args(caseroot)
         cmake_args = "-DCMAKE_Fortran_COMPILER={} ".format(arg_dict["SFC"])
@@ -163,9 +165,23 @@ def _build_json_fortran(caseroot, libroot, bldroot):
         _run_cmd("cmake {}".format(cmake_args), bldpath)
         _run_cmd(case.get_value("GMAKE"), bldpath)
 
+        # add json-fortran to include paths
+        incldir = os.environ.get('USER_INCLDIR')
+        if incldir is None:
+            incldir = ''
+        os.environ['USER_INCLDIR'] = incldir + \
+            " -I{} ".format(os.path.join(bldroot, "json-fortran", "include"))
+
+        # The built library is included in the CAM_LINKED_LIBS entry in
+        # config_component.xml and is staged here to the lib folder
+        os.rename(os.path.join(bldroot, "json-fortran", "lib", "libjsonfortran.a"), \
+                  os.path.join(libroot, "libjsonfortran.a"))
+
 ###############################################################################
 def _build_tuvx(caseroot, libroot, bldroot):
 ###############################################################################
+# Builds the TUV-x library and updates the case variables used to set the
+# include paths and linked libraries
 
     build = EnvBuild(case_root=caseroot)
     with Case(caseroot) as case:
@@ -175,7 +191,7 @@ def _build_tuvx(caseroot, libroot, bldroot):
         jsoninc = os.path.join(bldroot, "json-fortran", "include", "")
         expect(os.path.exists(jsoninc), \
                "JSON-Fortran include folder for TUV-x build not found at {}".format(jsoninc))
-        jsonlib = os.path.join(bldroot, "json-fortran", "lib", "libjsonfortran.a")
+        jsonlib = os.path.join(libroot, "libjsonfortran.a")
         expect(os.path.exists(jsonlib), \
                "JSON-Fortran library for TUV-x build not found at {}".format(jsonlib))
         srcpath = os.path.abspath(os.path.join(case.get_value("COMP_ROOT_DIR_ATM"), \
@@ -190,6 +206,7 @@ def _build_tuvx(caseroot, libroot, bldroot):
             cmake_args += "-DENABLE_MPI:BOOL=TRUE "
         cmake_args += "-DCMAKE_BUILD_TYPE=Release "
         cmake_args += "-DENABLE_COVERAGE=OFF "
+        cmake_args += "-DENABLE_TESTS=OFF "
         cmake_args += "-DJSON_INCLUDE_DIR={} ".format(jsoninc)
         cmake_args += "-DJSON_LIB={} ".format(jsonlib)
         cmake_args += "-DCMAKE_Fortran_FLAGS='{}' ".format(arg_dict["FFLAGS"])
@@ -197,6 +214,20 @@ def _build_tuvx(caseroot, libroot, bldroot):
 
         _run_cmd("cmake {}".format(cmake_args), bldpath)
         _run_cmd(case.get_value("GMAKE"), bldpath)
+
+        # add TUV-x to include paths
+        incldir = os.environ.get('USER_INCLDIR')
+        if incldir is None:
+            incldir = ''
+        os.environ['USER_INCLDIR'] = incldir + \
+            " -I{} ".format(os.path.join(bldroot, "tuv-x", "include"))
+
+        # The built libraries are included in the CAM_LINKED_LIBS entry in
+        # config_component.xml and are staged here to the lib folder
+        os.rename(os.path.join(bldroot, "tuv-x", "lib", "libmusica.a"), \
+                  os.path.join(libroot, "libmusica.a"))
+        os.rename(os.path.join(bldroot, "tuv-x", "lib", "libtuvx.a"), \
+                  os.path.join(libroot, "libtuvx.a"))
 
 ###############################################################################
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -199,6 +199,14 @@ def buildnml(case, caseroot, compname):
         if (os.path.isfile(file1)) and (not os.path.isfile(file2)):
             shutil.copy(file1,file2)
 
+        # Temporary copy of TUV-x data for development
+        dest_data = os.path.join(rundir, "data")
+        if os.path.exists(dest_data):
+            shutil.rmtree(dest_data)
+        shutil.copytree(os.path.join(srcroot, "libraries", "tuv-x", "data"), dest_data)
+        shutil.copy2(os.path.join(srcroot, "libraries", "tuv-x", "examples", "full_config.json"), \
+                     os.path.join(rundir, "tuvx_config.json"))
+
 ###############################################################################
 def _main_func():
 

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -190,6 +190,18 @@
     </desc>
   </entry>
 
+  <entry id="CAM_LINKED_LIBS">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value>-ltuvx -lmusica -ljsonfortran</default_value>
+    <group>build_component_cam</group>
+    <file>env_build.xml</file>
+    <desc>
+      CAM linked libraries. The libraries are built by CAM's buildlib script and should be included
+      during linking of the model executable.
+    </desc>
+  </entry>
+
   <entry id="CAM_NML_USE_CASE">
     <type>char</type>
     <valid_values></valid_values>

--- a/src/chemistry/mozart/mo_chemini.F90
+++ b/src/chemistry/mozart/mo_chemini.F90
@@ -48,6 +48,7 @@ contains
     use mo_srf_emissions,  only : srf_emissions_inti
     use mo_sulf,           only : sulf_inti
     use mo_photo,          only : photo_inti
+    use mo_tuvx,           only : tuvx_init
     use mo_lightning,      only : lightning_inti
     use mo_drydep,         only : drydep_inti
     use mo_imp_sol,        only : imp_slv_inti
@@ -199,6 +200,13 @@ contains
          exo_coldens_file, photo_max_zen )
 
     if (masterproc) write(iulog,*) 'chemini: after photo_inti on node ',iam
+
+    !-----------------------------------------------------------------------
+    ! 	... initialize the TUV-x photolysis rate constant calculator
+    !-----------------------------------------------------------------------
+
+    call tuvx_init( )
+    if (masterproc) write(iulog,*) 'chemini: after tuvx_init on node ',iam
 
     !-----------------------------------------------------------------------
     !	... initialize ion production

--- a/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -249,6 +249,7 @@ contains
     use chem_mods,         only : nabscol, nfs, indexm, clscnt4
     use physconst,         only : rga
     use mo_photo,          only : set_ub_col, setcol, table_photo
+    use mo_tuvx,           only : tuvx_get_photo_rates
     use mo_exp_sol,        only : exp_sol
     use mo_imp_sol,        only : imp_sol
     use mo_setrxt,         only : setrxt
@@ -787,6 +788,11 @@ contains
     call table_photo( reaction_rates, pmid, pdel, tfld, zmid, zint, &
                       col_dens, zen_angle, asdir, cwat, cldfr, &
                       esfact, vmr, invariants, ncol, lchnk, pbuf )
+
+    !-----------------------------------------------------------------
+    !	... get calculated photolysis rates from TUV-x
+    !-----------------------------------------------------------------
+    call tuvx_get_photo_rates( ncol )
 
     do i = 1,phtcnt
        call outfld( tag_names(i), reaction_rates(:ncol,:,rxt_tag_map(i)), ncol, lchnk )

--- a/src/chemistry/mozart/mo_tuvx.F90
+++ b/src/chemistry/mozart/mo_tuvx.F90
@@ -117,7 +117,7 @@ contains
 !-----------------------------------------------------------------------
 !
 ! Purpose: returns the id of the current OpenMP thread, or 1 if not
-!          using OpenMP
+!          using OpenMP (1 <= id <= max_threads())
 !
 !-----------------------------------------------------------------------
 #ifdef _OPENMP
@@ -125,7 +125,7 @@ contains
 #endif
 
 #ifdef _OPENMP
-    thread_id = omp_get_thread_num( )
+    thread_id = 1 + omp_get_thread_num( )
 #else
     thread_id = 1
 #endif

--- a/src/chemistry/mozart/mo_tuvx.F90
+++ b/src/chemistry/mozart/mo_tuvx.F90
@@ -1,0 +1,167 @@
+module mo_tuvx
+  !----------------------------------------------------------------------
+  !     ... wrapper for TUV-x photolysis rate constant calculator
+  !----------------------------------------------------------------------
+
+#ifdef _MPI
+  use mpi
+#endif
+  use tuvx_core,        only : core_t
+
+  implicit none
+
+  private
+
+  public :: tuvx_init
+  public :: tuvx_finalize
+
+  ! TUV-x calculator for each OMP thread
+  type :: tuvx_ptr
+    type(core_t), pointer :: core_ => null( )
+  end type tuvx_ptr
+  type(tuvx_ptr), allocatable :: tuvx_ptrs(:)
+
+  ! TODO where should this path be stored?
+  character(len=*), parameter :: tuvx_config_path = "tuvx_config.json"
+  ! TODO how to know what MPI communicator to use?
+#ifdef _MPI
+  integer, parameter :: tuvx_comm = MPI_COMM_WORLD
+#else
+  integer, parameter :: tuvx_comm = 0
+#endif
+
+!================================================================================================
+contains
+!================================================================================================
+
+  subroutine tuvx_init( )
+!-----------------------------------------------------------------------
+!
+! Purpose: initialize TUV-x for photolysis calculations
+!
+!-----------------------------------------------------------------------
+
+    use cam_logfile,    only : iulog
+    use musica_string,  only : string_t, to_char
+    use spmd_utils,     only : main_task => masterprocid, &
+                               is_main_task => masterproc
+
+!-----------------------------------------------------------------------
+! Local variables
+!-----------------------------------------------------------------------
+    class(core_t), pointer :: core
+    character, allocatable :: buffer(:)
+    type(string_t) :: config_path
+    integer :: pack_size, pos, i_core, i_err
+    character(len=255) :: cwd
+
+    call getcwd(cwd)
+    config_path = tuvx_config_path
+    if( is_main_task ) then
+      write(iulog,*) "Initializing TUV-x on MPI Task "//trim( to_char( main_task ) ) &
+                     //" and OpenMP thread "//trim( to_char( thread_id( ) ) ) &
+                     //" for "//trim( to_char( max_threads( ) ) )//" threads."
+      write(iulog,*) "TUV-x working dir: '"//trim(cwd) &
+                      //"' config path: '"//config_path//"'"
+    end if
+
+#if 0
+    ! construct a core on the primary process and pack it onto an MPI buffer
+    if( is_main_task ) then
+      core => core_t( config_path )
+      pack_size = core%pack_size( tuvx_comm )
+      allocate( buffer( pack_size ) )
+      pos = 0
+      call core%mpi_pack( buffer, pos, tuvx_comm )
+      deallocate( core )
+    end if
+
+    ! broadcast the core data to all MPI processes
+#ifdef _MPI
+    call mpi_bcast( pack_size, 1, MPI_INTEGER, main_task, tuvx_comm, i_err )
+    if( .not. is_main_task ) allocate( buffer( pack_size ) )
+    call mpi_bcast( buffer, pack_size, MPI_CHARACTER, main_task, tuvx_comm, i_err )
+#endif
+
+    ! unpack the core for each OMP thread on every MPI process
+    allocate( tuvx_ptrs( max_threads( ) ) )
+    do i_core = 1, size( tuvx_ptrs )
+    associate( tuvx => tuvx_ptrs( i_core ) )
+      allocate( tuvx%core_ )
+      pos = 0
+      call tuvx%core_%mpi_unpack( buffer, pos, tuvx_comm )
+    end associate
+    end do
+#endif
+
+  end subroutine tuvx_init
+
+!================================================================================================
+
+  subroutine tuvx_finalize( )
+!-----------------------------------------------------------------------
+!
+! Purpose: clean up memory associated with TUV-x calculators
+!
+!-----------------------------------------------------------------------
+
+!-----------------------------------------------------------------------
+! Local variables
+!-----------------------------------------------------------------------
+    integer :: i_core
+
+    if( allocated( tuvx_ptrs ) ) then
+      do i_core = 1, size( tuvx_ptrs )
+        if( associated( tuvx_ptrs( i_core )%core_ ) ) then
+          deallocate( tuvx_ptrs( i_core )%core_ )
+        end if
+      end do
+    end if
+
+  end subroutine tuvx_finalize
+
+!================================================================================================
+
+  integer function thread_id( )
+!-----------------------------------------------------------------------
+!
+! Purpose: returns the id of the current OpenMP thread, or 1 if not
+!          using OpenMP
+!
+!-----------------------------------------------------------------------
+#ifdef _OPENMP
+    use omp_lib,        only : omp_get_thread_num
+#endif
+
+#ifdef _OPENMP
+    thread_id = omp_get_thread_num( )
+#else
+    thread_id = 1
+#endif
+
+  end function thread_id
+
+!================================================================================================
+
+  integer function max_threads( )
+!-----------------------------------------------------------------------
+!
+! Purpose: returns the number of threads available for calculations at
+!          runtime
+!
+!-----------------------------------------------------------------------
+#ifdef _OPENMP
+    use omp_lib,        only : omp_get_max_threads
+#endif
+
+#ifdef _OPENMP
+    max_threads = omp_get_max_threads( )
+#else
+    max_threads = 1
+#endif
+
+  end function max_threads
+
+!================================================================================================
+
+end module mo_tuvx


### PR DESCRIPTION
closes #162 on TUV-x repo.

Includes wrapper for TUV-x in CAM with initialization and finalization functions. TUV-x cores are initialized for each OpenMP thread and each MPI task.

Temporarily copies TUV-x configuration data to run directory for use during development until https://github.com/NCAR/tuv-x/issues/163 is completed.

Linking the TUV-x, json-fortran, and musica libraries required a minor modification to CMEPS. I will follow up with CIME developers to see if there is a better way to do this.

FOLLOW UP: I met briefly with Jim Edwards and showed him this approach to build the libraries. He said it looked ok high-level, and that we can submit a PR to CMEPS for the modification and they would go over it in more detail then.